### PR TITLE
Add naive OpenAI strategy and backtracking system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# stock_simulator
+# Stock Simulator
+
+This repository contains a toy backtracking system for stock strategies.
+
+## Strategy package
+
+The `strategy` package provides an abstract `Strategy` interface and a
+`NaiveStrategy` implementation that uses the OpenAI API. API keys are loaded
+via [`python-dotenv`](https://pypi.org/project/python-dotenv/).
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install openai python-dotenv
+   ```
+2. Create a `.env` file with `OPENAI_API_KEY` defined.
+3. Run the demo:
+   ```bash
+   python main.py
+   ```
+
+The demo shows both single-stock and market backtracking modes.

--- a/backtracking.py
+++ b/backtracking.py
@@ -1,0 +1,23 @@
+"""Simple backtracking system supporting single stock and market modes."""
+from __future__ import annotations
+
+from typing import Dict, Sequence
+
+from strategy.interface import Strategy
+
+
+class Backtracker:
+    """Orchestrate backtracking using a given strategy."""
+
+    def __init__(self, strategy: Strategy) -> None:
+        self.strategy = strategy
+
+    def single_stock_mode(self, history: Sequence[float]) -> str:
+        """Backtrack in single-stock mode using ``history``."""
+        return self.strategy.single_stock(history)
+
+    def market_mode(self, histories: Dict[str, Sequence[float]]) -> str:
+        """Backtrack in market mode for selected targets."""
+        targets = self.strategy.get_targets()
+        subset = {t: histories[t] for t in targets if t in histories}
+        return self.strategy.market(subset)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+"""Entry point demonstrating the backtracking system."""
+from __future__ import annotations
+
+from backtracking import Backtracker
+from strategy import NaiveStrategy
+
+
+def main() -> None:
+    strategy = NaiveStrategy()
+    backtracker = Backtracker(strategy)
+
+    # Example usage in single stock mode
+    history = [100.0, 101.5, 102.3]
+    try:
+        single_result = backtracker.single_stock_mode(history)
+        print("Single stock result:\n", single_result)
+    except Exception as exc:  # pragma: no cover - example run guard
+        print("Single stock mode failed:", exc)
+
+    # Example usage in market mode
+    histories = {
+        "AAPL": [150.0, 151.2, 152.3],
+        "GOOG": [2700.0, 2710.5, 2699.0],
+        "MSFT": [299.0, 300.5, 305.0],
+    }
+    try:
+        market_result = backtracker.market_mode(histories)
+        print("Market mode result:\n", market_result)
+    except Exception as exc:  # pragma: no cover - example run guard
+        print("Market mode failed:", exc)
+
+
+if __name__ == "__main__":  # pragma: no cover - script execution
+    main()

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,6 @@
+"""Strategy package exposing interfaces and implementations."""
+
+from .interface import Strategy
+from .naive import NaiveStrategy
+
+__all__ = ["Strategy", "NaiveStrategy"]

--- a/strategy/interface.py
+++ b/strategy/interface.py
@@ -1,0 +1,24 @@
+"""Strategy interface for stock backtracking systems."""
+from abc import ABC, abstractmethod
+from typing import Dict, List, Sequence
+
+
+class Strategy(ABC):
+    """Abstract base class for trading strategies."""
+
+    @property
+    @abstractmethod
+    def target_change_frequency(self) -> int:
+        """Number of iterations before target list should be refreshed."""
+
+    @abstractmethod
+    def get_targets(self) -> Sequence[str]:
+        """Return a sequence of stock tickers to track in market mode."""
+
+    @abstractmethod
+    def single_stock(self, history: Sequence[float]) -> str:
+        """Analyze history for a single stock."""
+
+    @abstractmethod
+    def market(self, histories: Dict[str, Sequence[float]]) -> str:
+        """Analyze histories for multiple stocks."""

--- a/strategy/naive.py
+++ b/strategy/naive.py
@@ -1,0 +1,35 @@
+"""Naive strategy that queries the OpenAI API."""
+from __future__ import annotations
+
+from typing import Dict, Sequence
+
+from .interface import Strategy
+from . import prompt
+from .openai_api import ask_openai
+
+
+class NaiveStrategy(Strategy):
+    """Very naive strategy that simply forwards prompts to OpenAI."""
+
+    def __init__(self, target_change_frequency: int = 5) -> None:
+        self._freq = target_change_frequency
+        self._targets: Sequence[str] = ("AAPL", "GOOG", "MSFT")
+
+    # ------------------------------------------------------------------
+    @property
+    def target_change_frequency(self) -> int:  # pragma: no cover - simple getter
+        return self._freq
+
+    # ------------------------------------------------------------------
+    def get_targets(self) -> Sequence[str]:
+        return self._targets
+
+    # ------------------------------------------------------------------
+    def single_stock(self, history: Sequence[float]) -> str:
+        p = prompt.single_stock_prompt(history)
+        return ask_openai(p)
+
+    # ------------------------------------------------------------------
+    def market(self, histories: Dict[str, Sequence[float]]) -> str:
+        p = prompt.market_prompt(histories)
+        return ask_openai(p)

--- a/strategy/openai_api.py
+++ b/strategy/openai_api.py
@@ -1,0 +1,42 @@
+"""Wrapper around the OpenAI API using dotenv for key management."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+
+try:
+    import openai
+except Exception as exc:  # pragma: no cover - import guard
+    openai = None  # type: ignore
+    _import_error = exc
+else:
+    _import_error = None
+
+
+load_dotenv()
+
+
+def ask_openai(prompt: str) -> str:
+    """Send ``prompt`` to OpenAI and return the response text.
+
+    Raises:
+        RuntimeError: if the OpenAI package is missing or the API key is unset.
+    """
+
+    if _import_error is not None:
+        raise RuntimeError(
+            "openai package is required. Install with `pip install openai`."
+        ) from _import_error
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+    openai.api_key = api_key
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"].strip()

--- a/strategy/prompt.py
+++ b/strategy/prompt.py
@@ -1,0 +1,19 @@
+"""Prompt generation utilities for strategies."""
+from typing import Dict, Sequence
+
+
+def single_stock_prompt(history: Sequence[float]) -> str:
+    """Return a prompt for analyzing a single stock history."""
+    return (
+        "You are a trading assistant. Given the following price history "
+        f"{list(history)}, provide a short analysis and next action."
+    )
+
+
+def market_prompt(histories: Dict[str, Sequence[float]]) -> str:
+    """Return a prompt for analyzing multiple stock histories."""
+    lines = ["You are a trading assistant. Analyze these stocks:"]
+    for ticker, prices in histories.items():
+        lines.append(f"- {ticker}: {list(prices)}")
+    lines.append("Provide a concise analysis of the market.")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `strategy` package with abstract `Strategy` interface and naive OpenAI-based implementation
- implement simple backtracking system with single stock and market modes
- provide demo `main.py` and updated README with setup instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb9812db588325b4997a75e68f5f31